### PR TITLE
Support React 17 & 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "steerpath-smart-sdk": "^2.2.2"
   },
   "peerDependencies": {
-    "react": "^16.5.0",
+    "react": "^16.5.0 || ^17.0.0 || ^18.0.0",
     "react-native": ">=0.57.0-rc.0 <1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
The rationale of this would be to enable using newer React versions. I have tested the SDK to actually work with React Native 0.69 and 0.70 + Expo 46.