### PR TITLE
Update web sdk 2.2.6

### DIFF
--- a/example/src/Drawer.js
+++ b/example/src/Drawer.js
@@ -218,6 +218,11 @@ export default class Drawer extends Component {
     console.log("this.getUserTaskResponseBlock", data);
   }
 
+  getSmartMapCameraOptions = () => {
+    const smartMapCameraOptions = this.props.smartMapRef.current.getSmartMapCameraOptions()
+    console.log('smartMapCameraOptions: ', smartMapCameraOptions);
+  }
+
   setCamera = (type) => {
     let localRef = "Mobile development";
     let cameraOptions = {
@@ -457,6 +462,10 @@ export default class Drawer extends Component {
             <Button
               title="Reset widget padding"
               onPress={this.resetWidgetPadding}
+            />
+            <Button
+              title="Get SmartMap Camera Options"
+              onPress={this.getSmartMapCameraOptions}
             />
             <Button
               title="Set camera location"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -10783,9 +10783,9 @@ react-native-reanimated@~2.8.0:
     string-hash-64 "^1.0.3"
 
 "react-native-steerpath-smart-map@file:..":
-  version "1.17.7"
+  version "1.17.8"
   dependencies:
-    steerpath-smart-sdk "^2.2.5"
+    steerpath-smart-sdk "^2.2.6"
 
 react-native-web@0.17.7:
   version "0.17.7"
@@ -11960,10 +11960,10 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-steerpath-smart-sdk@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/steerpath-smart-sdk/-/steerpath-smart-sdk-2.2.5.tgz#826a2890383a2d06f702152cc637505e9d179cd3"
-  integrity sha512-X79s0yE0fjlhmk1ZFB8xSg8N6nF44/rfdjxqAltbDcrTUs0NOGzIX/JuQsR05NJP1g1elopFjGmOSQAjg4iGDQ==
+steerpath-smart-sdk@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/steerpath-smart-sdk/-/steerpath-smart-sdk-2.2.6.tgz#126a843908ab280f9af23536ae01974e41c8cf64"
+  integrity sha512-x8thGgiVglQtsY6nRBXnK5UtXJcpsDT+hqfdH8ZyzkoqIjeBJhEZmP2s9RepusivOuv3QPOKzP15e/EwgChhjw==
 
 stream-browserify@^2.0.1:
   version "2.0.2"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "dependencies": {
-    "steerpath-smart-sdk": "^2.2.5"
+    "steerpath-smart-sdk": "^2.2.6"
   },
   "peerDependencies": {
     "react": "^16.5.0",

--- a/src/SmartMapView.web.tsx
+++ b/src/SmartMapView.web.tsx
@@ -24,6 +24,7 @@ const COMPONENT_ID_PREFIX = "map_container_id";
 // Implementation for the smart map reference
 interface SmartMapRef {
   removeMap: Function;
+  getSmartMapCameraOptions: Function;
 }
 
 function runCommand<ArgsT extends Array<unknown>>(
@@ -222,6 +223,10 @@ export const SmartMapView = forwardRef<SmartMapViewMethods, SmartMapViewProps>(
       },
       removeAllMarkers() {
         runCommand(smartMapRef.current, "removeAllMarkers", []);
+      },
+      getSmartMapCameraOptions() {
+        const smartMapCameraOptions = smartMapRef.current ? smartMapRef.current.getSmartMapCameraOptions() : null
+        return smartMapCameraOptions;
       },
       animateCamera({
         latitude,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,10 +4016,10 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-steerpath-smart-sdk@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/steerpath-smart-sdk/-/steerpath-smart-sdk-2.2.5.tgz#826a2890383a2d06f702152cc637505e9d179cd3"
-  integrity sha512-X79s0yE0fjlhmk1ZFB8xSg8N6nF44/rfdjxqAltbDcrTUs0NOGzIX/JuQsR05NJP1g1elopFjGmOSQAjg4iGDQ==
+steerpath-smart-sdk@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/steerpath-smart-sdk/-/steerpath-smart-sdk-2.2.6.tgz#126a843908ab280f9af23536ae01974e41c8cf64"
+  integrity sha512-x8thGgiVglQtsY6nRBXnK5UtXJcpsDT+hqfdH8ZyzkoqIjeBJhEZmP2s9RepusivOuv3QPOKzP15e/EwgChhjw==
 
 stream-buffers@~2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Updated web sdk to 2.2.6 so that there's a new API `getSmartMapCameraOptions` which returns following object:

```
{
                pitch: number
                bearing: number
                zoomLevel: number
                longitude: number
                latitude: number
            }
```

TODO:
- [x] typings once all platforms are done we can type the `smartMapCameraOptions` to be same on all platforms